### PR TITLE
Fix OR typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ const withAnimals = withGoogleSheets(
 );
 
 const withLoadingIndicator = branch(
-  props => props.initializing | props.loading,
+  props => props.initializing || props.loading,
   renderComponent(() => <span>Loading...</span>),
 );
 


### PR DESCRIPTION
Change the bitwise OR to a logical OR in the example usage.

Closes #9